### PR TITLE
Add pipeline haplotype_phylogeny

### DIFF
--- a/modules/bcftools.nf
+++ b/modules/bcftools.nf
@@ -1,0 +1,122 @@
+process BCFTOOLS_CALL_REGION_VARIANTS {
+
+    label "BCFTOOLS"
+
+    input:
+    path(cram)
+    path(sample_map)
+    path(ref_genome)
+    path(ref_ploidy)
+    val(region)
+
+    output:
+    path("${cram.simpleName}.vcf.gz"), emit: vcf
+
+    script:
+    """
+    bcftools mpileup \
+        --threads ${task.cpus} \
+        --targets ${region} \
+        --annotate DP \
+        --output-type b --output ${cram.simpleName}_tmp.bcf \
+        --fasta-ref ${ref_genome} \
+        ${cram}
+
+    # MAKE SAMPLES FILE TO MATCH PLOIDY FILE IN BCFTOOLS CALL
+    bcftools query --list-samples ${cram.simpleName}_tmp.bcf > samples.txt
+    while read -r sample; do
+        echo "^\$sample" >> samples_greps.txt
+    done < "samples.txt"
+    grep -f samples_greps.txt ${sample_map} > call.samples
+
+    bcftools call \
+        --threads ${task.cpus} \
+        --ploidy-file ${ref_ploidy} \
+        --samples-file call.samples \
+        --targets ${region} \
+        --variants-only \
+        --multiallelic-caller \
+        --output-type z --output ${cram.simpleName}.vcf.gz \
+        ${cram.simpleName}_tmp.bcf
+    """
+}
+
+process BCFTOOLS_INDEX {
+
+    label "BCFTOOLS"
+
+    input:
+    path(vcf)
+
+    output:
+    tuple path(vcf, includeInputs: true), path("${vcf.name}.csi"), emit: indexed_vcf
+
+    script:
+    """
+    bcftools index --threads ${task.cpus} ${vcf}
+    """
+}
+
+process BCFTOOLS_NORMALISE {
+
+    label "BCFTOOLS"
+
+    input:
+    tuple path(vcf), path(csi)
+    path(ref_genome)
+
+    output:
+    path("${vcf.simpleName}_norm.vcf.gz"), emit: normalised_vcf
+
+    script:
+    """
+    bcftools norm \
+        --threads ${task.cpus} \
+        --fasta-ref ${ref_genome} \
+        --output-type z --output ${vcf.simpleName}_norm.vcf.gz \
+        ${vcf}
+    """
+}
+
+process BCFTOOLS_FILTER {
+
+    label "BCFTOOLS"
+
+    input:
+    tuple path(vcf), path(csi)
+    val(indelgap)
+    val(inclusions)
+
+    output:
+    path("${vcf.simpleName}_filt.vcf.gz"), emit: filtered_vcf
+
+    script:
+    """
+    bcftools filter \
+        --threads ${task.cpus} \
+        --IndelGap ${indelgap} \
+        --include "${inclusions}" \
+        --output-type z --output ${vcf.simpleName}_filt.vcf.gz \
+        ${vcf}
+    """
+}
+
+process BCFTOOLS_MAKE_CONSENSUS_FASTA {
+
+    label "BCFTOOLS"
+
+    input:
+    tuple path(vcf), path(csi)
+    path(ref_genome)
+
+    output:
+    tuple env("samples"), path("${vcf.simpleName}.fasta.gz"), emit: fasta
+
+    script:
+    """
+    samples=\$(bcftools query --list-samples ${vcf})
+    cat ${ref_genome} \
+    | bcftools consensus --samples \$samples ${vcf} \
+    | bgzip -c > ${vcf.simpleName}.fasta.gz
+    """
+}

--- a/modules/iqtree.nf
+++ b/modules/iqtree.nf
@@ -1,0 +1,37 @@
+process IQTREE_BUILD_TREE {
+
+    label "IQTREE"
+
+    input:
+    path(alignment)
+    val(bootstraps)
+
+    output:
+    path("${alignment.name}.*"), emit: all_treefiles
+    path("${alignment.name}.contree"), emit: contree
+
+    script:
+    """
+    iqtree -s ${alignment} -bb ${bootstraps} -m MFP -T AUTO --out-format FASTA
+    """
+}
+
+process IQTREE_TO_PLAIN_NEWICK {
+
+    label "RBASE"
+
+    input:
+    path(contree)
+
+    output:
+    path("${contree.simpleName}.nwk")
+
+    script:
+    """
+    #!/usr/bin/env Rscript
+    contree <- readLines("${contree.toString()}")
+    rm_bootstrap <- gsub(":([0-9.])+", "", contree)
+    rm_branchlen <- gsub("\\\\)([0-9.])+", ")", rm_bootstrap)
+    writeLines(rm_branchlen, "${contree.simpleName.toString()}.nwk")
+    """
+}

--- a/modules/mafft.nf
+++ b/modules/mafft.nf
@@ -1,0 +1,16 @@
+process MAFFT_ALIGN {
+
+    label "MAFFT"
+
+    input:
+    path(fasta)
+    val(max_iterations)
+
+    output:
+    path("${fasta.simpleName}_aligned.fasta"), emit: aligned
+
+    script:
+    """
+    mafft --maxiterate ${max_iterations} --thread ${task.cpus} ${fasta} > ${fasta.simpleName}_aligned.fasta
+    """
+}

--- a/modules/samtools.nf
+++ b/modules/samtools.nf
@@ -1,0 +1,33 @@
+process SAMTOOLS_INDEX_FASTA {
+
+    label "SAMTOOLS"
+
+    input:
+    tuple val(sample), path(fasta)
+
+    output:
+    tuple val(sample), path(fasta, includeInputs: true), path("${fasta.name}.fai"), emit: indexed_fasta
+
+    script:
+    """
+    samtools faidx ${fasta}
+    """
+}
+
+process SAMTOOLS_EXTRACT_REGION {
+
+    label "SAMTOOLS"
+
+    input:
+    tuple val(sample), path(fasta), path(fai)
+    val(region)
+
+    output:
+    path("${sample}_${region}.fasta"), emit: extracted
+
+    script:
+    """
+    samtools faidx ${fasta} ${region} > ${sample}_${region}.fasta
+    sed -i -e 's/>${region}/>${sample}/g' ${sample}_${region}.fasta
+    """
+}

--- a/modules/system.nf
+++ b/modules/system.nf
@@ -1,0 +1,16 @@
+process CONCATENATE_FILES {
+
+    label "SYSTEM"
+
+    input:
+    path(files, stageAs: "inputs/*")
+    val(catfile)
+
+    output:
+    path("${catfile}"), emit: concat
+
+    script:
+    """
+    find inputs/ -type f,l | xargs cat > ${catfile}
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -21,15 +21,22 @@ profiles {
 
 process {
 
-  withLabel: "PLINK" {
-    container = "quay.io/biocontainers/plink:1.90b7.7--h18e278d_1"
+  withLabel: "ADMIXTURE" {
+    container = "quay.io/biocontainers/admixture:1.3.0--0"
     cpus = 4
     memory = 8.GB
     time = 4.h
   }
 
-  withLabel: "ADMIXTURE" {
-    container = "quay.io/biocontainers/admixture:1.3.0--0"
+  withLabel: "BCFTOOLS" {
+    container = "quay.io/biocontainers/bcftools:1.22--h3a4d415_1"
+    cpus = 4
+    memory = 8.GB
+    time = 4.h
+  }
+
+  withLabel: "PLINK" {
+    container = "quay.io/biocontainers/plink:1.90b7.7--h18e278d_1"
     cpus = 4
     memory = 8.GB
     time = 4.h

--- a/nextflow.config
+++ b/nextflow.config
@@ -49,4 +49,11 @@ process {
     time = 4.h
   }
 
+  withLabel: "SAMTOOLS" {
+    container = "quay.io/biocontainers/samtools:1.19.2--h50ea8bc_1"
+    cpus = 4
+    memory = 8.GB
+    time = 4.h
+  }
+
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -35,6 +35,13 @@ process {
     time = 4.h
   }
 
+  withLabel: "MAFFT" {
+    container = "quay.io/biocontainers/mafft:7.490--hec16e2b_1"
+    cpus = 4
+    memory = 8.GB
+    time = 4.h
+  }
+
   withLabel: "PLINK" {
     container = "quay.io/biocontainers/plink:1.90b7.7--h18e278d_1"
     cpus = 4

--- a/nextflow.config
+++ b/nextflow.config
@@ -35,6 +35,13 @@ process {
     time = 4.h
   }
 
+  withLabel: "IQTREE" {
+    container = "quay.io/biocontainers/iqtree:3.0.1--h503566f_0"
+    cpus = 4
+    memory = 8.GB
+    time = 4.h
+  }
+
   withLabel: "MAFFT" {
     container = "quay.io/biocontainers/mafft:7.490--hec16e2b_1"
     cpus = 4

--- a/nextflow.config
+++ b/nextflow.config
@@ -56,4 +56,10 @@ process {
     time = 4.h
   }
 
+  withLabel: "SYSTEM" {
+    cpus = 4
+    memory = 8.GB
+    time = 4.h
+  }
+
 }

--- a/pipelines/haplotype_phylogeny.nf
+++ b/pipelines/haplotype_phylogeny.nf
@@ -1,0 +1,42 @@
+include { BCFTOOLS_CALL_REGION_VARIANTS; BCFTOOLS_NORMALISE; BCFTOOLS_FILTER } from "../modules/bcftools.nf"
+include { BCFTOOLS_INDEX; BCFTOOLS_INDEX as BCFTOOLS_INDEX_NORMALISED; BCFTOOLS_INDEX as BCFTOOLS_INDEX_FILTERED } from "../modules/bcftools.nf"
+include { BCFTOOLS_MAKE_CONSENSUS_FASTA } from "../modules/bcftools.nf"
+include { SAMTOOLS_EXTRACT_REGION; SAMTOOLS_INDEX_FASTA } from "../modules/samtools.nf"
+include { CONCATENATE_FILES as CONCATENATE_FASTAS } from "../modules/system.nf"
+include { MAFFT_ALIGN } from "../modules/mafft.nf"
+include { IQTREE_BUILD_TREE; IQTREE_TO_PLAIN_NEWICK } from "../modules/iqtree.nf"
+
+nextflow.preview.output = true
+
+workflow {
+    main:
+    crams = Channel.fromPath("${params.cramdir}/**.cram")
+    BCFTOOLS_CALL_REGION_VARIANTS(crams, params.sample_map, params.ref_genome, params.ref_ploidy, params.genome_region)
+    BCFTOOLS_INDEX(BCFTOOLS_CALL_REGION_VARIANTS.out.vcf)
+    BCFTOOLS_NORMALISE(BCFTOOLS_INDEX.out.indexed_vcf, params.ref_genome)
+    BCFTOOLS_INDEX_NORMALISED(BCFTOOLS_NORMALISE.out.normalised_vcf)
+    BCFTOOLS_FILTER(BCFTOOLS_INDEX_NORMALISED.out.indexed_vcf, params.filt_indelgap, params.filt_inclusions)
+    BCFTOOLS_INDEX_FILTERED(BCFTOOLS_FILTER.out.filtered_vcf)
+    BCFTOOLS_MAKE_CONSENSUS_FASTA(BCFTOOLS_INDEX_FILTERED.out.indexed_vcf, params.ref_genome)
+    SAMTOOLS_INDEX_FASTA(BCFTOOLS_MAKE_CONSENSUS_FASTA.out.fasta)
+    SAMTOOLS_EXTRACT_REGION(SAMTOOLS_INDEX_FASTA.out.indexed_fasta, params.genome_region)
+    haplotype_fastas = SAMTOOLS_EXTRACT_REGION.out.extracted.collect()
+
+    CONCATENATE_FASTAS(haplotype_fastas, "${params.genome_region}.fasta")
+    MAFFT_ALIGN(CONCATENATE_FASTAS.out.concat, params.mafft_iterations)
+    IQTREE_BUILD_TREE(MAFFT_ALIGN.out.aligned, params.iqtree_bootstraps)
+    IQTREE_TO_PLAIN_NEWICK(IQTREE_BUILD_TREE.out.contree)
+
+    publish:
+    fasta = SAMTOOLS_EXTRACT_REGION.out
+    iqtree = IQTREE_BUILD_TREE.out.all_treefiles
+    alignment = MAFFT_ALIGN.out.aligned
+    plain_newick = IQTREE_TO_PLAIN_NEWICK.out
+}
+
+output {
+    fasta { path "haplotype_phylogeny/fasta" }
+    iqtree { path "haplotype_phylogeny/iqtree" }
+    alignment { path "haplotype_phylogeny/hapsolutely" }
+    plain_newick { path "haplotype_phylogeny/hapsolutely" }
+}

--- a/pipelines/haplotype_phylogeny.param.yaml
+++ b/pipelines/haplotype_phylogeny.param.yaml
@@ -1,0 +1,9 @@
+cramdir: 
+sample_map: 
+ref_genome: /cluster/projects/nn10082k/ref/house_sparrow_genome_assembly-18-11-14_masked.fa
+ref_ploidy: 
+genome_region: mtDNA
+filt_indelgap: 5
+filt_inclusions: 'QUAL>20 & FMT/DP>5 & FMT/DP<75'
+mafft_iterations: 1000
+iqtree_bootstraps: 1000

--- a/pipelines/haplotype_phylogeny.slurm.sh
+++ b/pipelines/haplotype_phylogeny.slurm.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# ADMIN
+#SBATCH --job-name=haplotype_phylogeny
+#SBATCH --output=SLURM-%j-%x.out
+#SBATCH --error=SLURM-%j-%x.err
+#SBATCH --account=nn10082k
+
+# RESOURCE ALLOCATION
+#SBATCH --nodes=1
+#SBATCH --tasks=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem-per-cpu=4G
+#SBATCH --time=48:00:00
+
+# USER INPUT: Define absolute path to pipelines repository
+repodir=
+
+# USER CONFIGURATION: Enable Nextflow (if necessary)
+module --quiet purge
+module load Miniconda3/22.11.1-1
+source ${EBROOTMINICONDA3}/bin/activate
+conda activate /cluster/projects/nn10082k/conda_group/Nextflow25.04.6
+
+# Begin work
+set -o errexit
+set -o nounset
+cd ${repodir}
+
+nextflow -log .nextflow/nextflow.log \
+    run ./pipelines/haplotype_phylogeny.nf \
+    -params-file pipelines/haplotype_phylogeny.param.yaml \
+    -profile saga
+
+# End work

--- a/pipelines/population_structure.nf
+++ b/pipelines/population_structure.nf
@@ -3,7 +3,6 @@ include { PLINK_EXTRACT_SITES as PLINK_EXTRACT_PRUNED; PLINK_EXTRACT_SITES as PL
 include { PLINK_FILTER; PLINK_FILTER as PLINK_REFILTER } from "../modules/plink.nf"
 include { ADMIXTURE; ADMIXTURE_AIMS } from "../modules/admixture.nf"
 
-// Output syntax current as of version 25.04.6
 nextflow.preview.output = true
 
 workflow {


### PR DESCRIPTION
Outputs files ready for use with e.g. Hapsolutely. Quick for (relatively) small genome regions such as mtDNA, and should in principle be usable for any region you might want to study as a haplotype.