### PR TITLE
Remove housekeeping section from nextflow.slurm.sh

### DIFF
--- a/nextflow.slurm.sh
+++ b/nextflow.slurm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# CONFIGURABLE: SLURM SETTIGNS
+# CONFIGURE: SLURM SETTIGNS
 #SBATCH --job-name=submit-pipeline
 #SBATCH --output=SLURM-%j-%x.out
 #SBATCH --error=SLURM-%j-%x.err
@@ -9,20 +9,15 @@
 #SBATCH --mem=4G
 #SBATCH --time=12:00:00
 
-# HOUSEKEEPING
-set -o errexit
-set -o nounset
-module --quiet purge
+# CHOOSE: PIPELINE
+pipeline=population_structure
 
-# CONFIGURABLE: NEXTFLOW
+# CONFIGURE: NEXTFLOW
 module load Miniconda3/22.11.1-1
 source ${EBROOTMINICONDA3}/bin/activate
 conda activate /cluster/projects/nn10082k/conda_group/Nextflow25.04.6
 
-# CONFIGURABLE: PIPELINE
-pipeline=population_structure
-
-# CONFIGURABLE: NEXTFLOW OPTIONS
+# CONFIGURE: NEXTFLOW OPTIONS
 nextflow -log .nextflow/nextflow.log run pipelines/${pipeline}.nf \
     -params-file nextflow.yaml \
     -profile saga


### PR DESCRIPTION
These settings suddenly lead to unexpected error-exits on Saga before Nextflow ever launches, potentially an issue with the interaction between Nextflow and Java in the Conda environment versus the base environment on Saga. This is unclear, though. Inelegant but efficient fix.